### PR TITLE
fix(ci): point pr-checks npm cache at actual lockfile locations

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,6 +32,15 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    # web/node_modules is (unusually) committed to the repo and can be stale
+    # relative to web/package.json (e.g. a dependency's package.json here may
+    # already report a version that satisfies package.json's range, so a
+    # plain `npm install` leaves its stale/incomplete files in place instead
+    # of reinstalling). Start from a clean slate so install actually reflects
+    # what's in package.json.
+    - name: Remove stale committed node_modules
+      run: rm -rf node_modules
+
     - name: Install dependencies
       run: npm install
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,38 +7,82 @@ on:
     branches: [ master, main ]
 
 jobs:
-  test:
+  # Generator UI (web/) — built into the `generator` Docker image via
+  # docker/Dockerfile.generator, which just runs `npm install && npm run build`.
+  # There is no committed lockfile for this project (root .gitignore excludes
+  # package-lock.json), so we mirror that exact install flow here and skip
+  # npm-cache/npm-ci/audit steps that depend on a lockfile being present.
+  test-web:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [18.x, 20.x]
-    
+
+    defaults:
+      run:
+        working-directory: web
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
+    - name: Setup Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run TypeScript build
+      run: npm run build
+
+    - name: Run linting
+      run: npm run lint --if-present
+
+    - name: Run tests
+      run: npm test --if-present
+
+  # Standalone UI (web/ui/) — has its own committed package-lock.json, so it
+  # can use npm ci with proper npm caching and lockfile verification.
+  test-web-ui:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    defaults:
+      run:
+        working-directory: web/ui
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-        
+        cache-dependency-path: web/ui/package-lock.json
+
     - name: Install dependencies
       run: npm ci
-      
+
     - name: Run TypeScript build
       run: npm run build
-      
+
     - name: Run linting
       run: npm run lint --if-present
-      
+
     - name: Run tests
       run: npm test --if-present
-      
+
     - name: Check for security vulnerabilities
       run: npm audit --audit-level high
-      
+
     - name: Verify package-lock.json is up to date
       run: |
         npm ci --package-lock-only


### PR DESCRIPTION
## Summary
- `pr-checks.yml` ran `actions/setup-node` with `cache: npm` at the repo root, but there is no root-level `package.json`/lockfile — the workflow has been failing on every push to `main` and every PR since it was added.
- Split the single root-level job into two jobs that match how Node is actually consumed in this repo:
  - `test-web`: mirrors `docker/Dockerfile.generator`'s `npm install && npm run build` for `web/` (no committed lockfile there — it's gitignored — so no `npm ci`/cache/audit steps that require one).
  - `test-web-ui`: keeps `npm ci` plus npm caching, now correctly pointed at `web/ui/package-lock.json` via `cache-dependency-path`, along with the original lint/test/audit/lockfile-verification steps.

## Test plan
- [x] `npm install && npm run build` verified locally for `web/`
- [x] `npm ci && npm run build && npm run lint` verified locally for `web/ui/`
- [ ] CI run on this PR goes green (watching)